### PR TITLE
feat: switch devicetype to computer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ async fn main() {
 
     let mut server = Discovery::builder(device_id.clone(), SessionConfig::default().client_id)
         .name(name.clone())
-        .device_type(DeviceType::Speaker)
+        .device_type(DeviceType::Computer)
         .launch()
         .unwrap();
 


### PR DESCRIPTION
## Changes

Change the DeviceType from Speaker (which requires Spotify Premium) to Computer (which does not).

Tested just now on a free account after building from source on Debian Bookworm